### PR TITLE
added passwordless script used in jenkins for node on Ec2 startup

### DIFF
--- a/bash_scripts/passwordless.sh
+++ b/bash_scripts/passwordless.sh
@@ -1,0 +1,10 @@
+#This script is used to connect to EC2 through SSH without having a key-pair
+
+#!/bin/bash
+sudo sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /etc/ssh/sshd_config
+sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+sudo service sshd restart
+sudo echo "root:password" | chpasswd
+sudo apt-get install openjdk-17-jre -y
+hostname Node-1
+


### PR DESCRIPTION
root:password -> root here refers to your username that you used while creating an EC2.
                        -> passwd refers to the password , you can give anything here.

the java version on node[slave] should match with the java version on master.
